### PR TITLE
Get schema from content response

### DIFF
--- a/middleware/swagger-router.js
+++ b/middleware/swagger-router.js
@@ -265,6 +265,10 @@ var mockResponse = function (req, res, next, handlerName) {
                                            JSON.stringify(getMockValue(req.swagger.swaggerVersion, result)));
         }
       });
+    } else if(req.swagger.swaggerVersion === '3.0.1') {
+      var contentType = req.headers['content-type'] || 'application/json';
+      var responseType = responseType.content[contentType].schema;
+      return sendResponse(undefined, JSON.stringify(getMockValue(req.swagger.swaggerVersion, responseType)));
     } else {
       return sendResponse(undefined, JSON.stringify(getMockValue(req.swagger.swaggerVersion, responseType.schema || responseType)));
     }

--- a/middleware/swagger-router.js
+++ b/middleware/swagger-router.js
@@ -383,7 +383,7 @@ exports = module.exports = function (options) {
         debug('    Ignored: %s', options.ignoreMissingHandlers === true ? 'yes' : 'no');
         debug('    Using mock: %s', options.useStubs && _.isUndefined(handler) ? 'yes' : 'no');
 
-        if (_.isUndefined(handler) && options.useStubs === true) {
+        if (_.isUndefined(handler) || options.useStubs === true) {
           handler = handlerCache[handlerName] = createStubHandler(handlerName);
         }
 


### PR DESCRIPTION
This makes 2 changes:
- Fix stub options to be used (since the option is ignored if the handler is defined).
- Fix get the schema from content type instead of the response body (only for 3.0.1).

Source: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#responseObject
