### PR TITLE
Update index.html

### DIFF
--- a/middleware/swagger-ui/index.html
+++ b/middleware/swagger-ui/index.html
@@ -35,26 +35,40 @@
 
     <script src="./swagger-ui-bundle.js"> </script>
     <script src="./swagger-ui-standalone-preset.js"> </script>
-    <script>
-    window.onload = function() {
-      // Begin Swagger UI call region
-      const ui = SwaggerUIBundle({
-        url: "https://petstore.swagger.io/v2/swagger.json",
-        dom_id: '#swagger-ui',
-        deepLinking: true,
-        presets: [
-          SwaggerUIBundle.presets.apis,
-          SwaggerUIStandalonePreset
-        ],
-        plugins: [
-          SwaggerUIBundle.plugins.DownloadUrl
-        ],
-        layout: "StandaloneLayout"
-      })
-      // End Swagger UI call region
 
-      window.ui = ui
-    }
-  </script>
+    <script>
+      window.onload = function() {
+        function initSwaggerUi (url) {
+          window.ui = SwaggerUIBundle({
+            url: url,
+            dom_id: '#swagger-ui',
+            deepLinking: true,
+            presets: [
+              SwaggerUIBundle.presets.apis,
+              SwaggerUIStandalonePreset
+            ],
+            plugins: [
+              SwaggerUIBundle.plugins.DownloadUrl
+            ],
+            layout: "StandaloneLayout",
+            validatorUrl: null
+          });
+        }
+        var xhr = new XMLHttpRequest();
+        xhr.open('HEAD', document.location.href);
+        xhr.onreadystatechange = function () {
+          var url = 'http://petstore.swagger.io/v2/swagger.json';
+          if (xhr.readyState === XMLHttpRequest.DONE) {
+            url = xhr.getResponseHeader('Swagger-API-Docs-URL');
+          } else {
+            console.log('Unable to get the Swagger UI URL from the server (%s): %s', xhr.status, xhr.responseText);
+          }
+          initSwaggerUi(url);
+        };
+        xhr.send(null);
+      }
+      </script>
+    
+    
   </body>
 </html>


### PR DESCRIPTION
I've been testing the /docs and found harcoded the http://petstore.swagger.io/v2/swagger.json which shows me the doc from the petstore always.

I've compared the html code from the forked https://github.com/apigee-127/swagger-tools/blob/master/middleware/swagger-ui/index.html.  This code inits the SwaggerUiBundle with an url given from the server and shows directly the doc from the api.