### PR TITLE
Fixing issue #17 NPM module not building correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "LICENSE",
     "lib",
     "src/middleware",
+    "dist/middleware",
     "schemas"
   ],
   "dependencies": {


### PR DESCRIPTION
Apparently npm pack ignoring everything except files from "files" section and "main" in package.json file. I have added "dist/middleware" for the npm pack to pickup.  