### PR TITLE
App options

### DIFF
--- a/examples/petstore/example.js
+++ b/examples/petstore/example.js
@@ -8,7 +8,13 @@ var serverPort = 8080;
 
 // swaggerRouter configuration
 var options = {
-    controllers: path.join(__dirname, './controllers')
+    routing: {
+        controllers: path.join(__dirname, './controllers')
+    },
+    logging: {
+        format: 'combined',
+        errorLimit: 400
+    }
 };
 
 var expressAppConfig = oas3Tools.expressAppConfig(path.join(__dirname, 'api/petstore.yaml'), options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 'use strict';
 import { ExpressAppConfig } from "./middleware/express.app.config";
 
-export function expressAppConfig(definitionPath: string, routingOptions): ExpressAppConfig {
-  return new ExpressAppConfig(definitionPath, routingOptions);
+export function expressAppConfig(definitionPath: string, appOptions): ExpressAppConfig {
+  return new ExpressAppConfig(definitionPath, appOptions);
 }


### PR DESCRIPTION
Added a more general app options parameter instead of a single routing parameter. This way the configuration of the app can be separated on multiple themes.

I needed to be able to configure the morgan logging module on another project and had to code a hack to do so as it was not accessible in ExpressAppConfig. No hacky way needed if we have appOptions object and not only a routingOptions parameter.

I added the possibility to configure the format of morgan log strings (https://github.com/expressjs/morgan#morganformat-options) and implemented an HTTP error limiter. I also updated the example.