### PR TITLE
Fix options not sent to SwaggerUI

### DIFF
--- a/src/middleware/express.app.config.ts
+++ b/src/middleware/express.app.config.ts
@@ -59,15 +59,18 @@ export class ExpressAppConfig {
 
     public configureLogger(loggerOptions){
         let format = 'dev';
-        if(loggerOptions.format != undefined
-            && typeof loggerOptions.format === 'string'){
-                format = loggerOptions.format;
-        }
-
         let options:{} = {};
-        if(loggerOptions.errorLimit != undefined
-            && (typeof loggerOptions.errorLimit === 'string' || typeof loggerOptions.errorLimit === 'number')){
-            options['skip'] = function (req, res) { return res.statusCode < parseInt(loggerOptions.errorLimit); };
+
+        if (loggerOptions != undefined) {
+            if(loggerOptions.format != undefined
+                && typeof loggerOptions.format === 'string'){
+                    format = loggerOptions.format;
+            }
+    
+            if(loggerOptions.errorLimit != undefined
+                && (typeof loggerOptions.errorLimit === 'string' || typeof loggerOptions.errorLimit === 'number')){
+                options['skip'] = function (req, res) { return res.statusCode < parseInt(loggerOptions.errorLimit); };
+            }
         }
 
         return logger(format, options);

--- a/src/middleware/express.app.config.ts
+++ b/src/middleware/express.app.config.ts
@@ -34,7 +34,7 @@ export class ExpressAppConfig {
         this.app.use(express.urlencoded({ extended: false }));
         this.app.use(cookieParser());
 
-        const swaggerUi = new SwaggerUI(swaggerDoc, undefined);
+        const swaggerUi = new SwaggerUI(swaggerDoc, appOptions);
         this.app.use(swaggerUi.serveStaticContent());
     }
 


### PR DESCRIPTION
Added the option in the SwaggerUI instance. This allow the users to edit 'apiDocsPath' and 'swaggerUIPath' to change the default path and to disable SwaggerUI for production if needed.

The logger configuration method is edited to not crash when the logger options are not set

Maybe document the Options available since this will break the default project generated by Swagger Editor. The controllers option is in the root of the options object instead of options.routing object.