### PR TITLE
XML support

### DIFF
--- a/examples/petstore/api/petstore.yaml
+++ b/examples/petstore/api/petstore.yaml
@@ -160,9 +160,6 @@ components:
           example: doggie
         photoUrls:
           type: array
-          xml:
-            name: photoUrl
-            wrapped: true
           items:
             type: string
         status:

--- a/examples/petstore/example.js
+++ b/examples/petstore/example.js
@@ -2,6 +2,7 @@
 
 var path = require('path');
 var http = require('http');
+var xml2js = require('xml2js');
 
 var oas3Tools = require('oas3-tools');
 var serverPort = 8080;
@@ -9,6 +10,24 @@ var serverPort = 8080;
 function validate(request, scopes, schema) {
     // security stuff here
     return true;
+}
+
+function doNothing(value, name){
+    //console.log(name, value);
+    return value;
+}
+
+function sanitiser(req, res, next){
+    //console.log(req.body);
+    let body = req.body;
+    if (body.photoUrls){
+        if (!Array.isArray(body.photoUrls) && typeof body.photoUrls === 'string'){
+            body.photoUrls = [body.photoUrls];
+        }
+    }
+    //console.log(body);
+    req.body = body;
+    next();
 }
 
 // swaggerRouter configuration
@@ -28,6 +47,11 @@ var options = {
                 api_key: validate
             }
         }
+    },
+    xml:{
+        tagNameProcessors: [xml2js.processors.stripPrefix],
+        valueProcessors: [xml2js.processors.parseNumbers, xml2js.processors.parseBooleans, doNothing],
+        sanitiseProcessors: sanitiser
     }
 }; 
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,12 @@
   "description": "Swagger-UI and API Rest Routing for Open API v3.",
   "main": "dist/index.js",
   "scripts": {
-    "build": "rm -rf dist/ && tsc && cp -R src/middleware/swagger-ui dist/middleware/swagger-ui"
+    "clean:dist": "rimraf dist",
+    "setup:dist": "make-dir dist",
+    "copy:middleware": "copyfiles -u 1 \"src/middleware/swagger-ui/**\" ./dist",
+    "build:tsc": "tsc",
+    "build:prod": "run-s build:tsc copy:middleware",
+    "build": "run-s clean:dist setup:dist build:prod"
   },
   "author": {
     "name": "Hugo Mercado",
@@ -33,10 +38,10 @@
   "dependencies": {
     "async": "^2.6.3",
     "body-parser": "1.19.0",
+    "body-parser-xml": "2.0.1",
     "cookie-parser": "^1.4.4",
     "debug": "^4.1.1",
-    "serve-static": "^1.14.1",
-    "express": "^4.17.1",
+    "express": "4.17.1",
     "express-openapi-validator": "^4.4.3",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.15",
@@ -44,7 +49,8 @@
     "multer": "^1.4.2",
     "parseurl": "^1.3.3",
     "path-to-regexp": "^3.2.0",
-    "qs": "^6.9.1"
+    "qs": "^6.9.1",
+    "serve-static": "^1.14.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.0",
@@ -55,6 +61,10 @@
     "@types/js-yaml": "^3.12.1",
     "@types/serve-static": "^1.13.3",
     "awesome-typescript-loader": "^5.2.1",
+    "copyfiles": "2.4.0",
+    "make-dir-cli": "^2.0.0",
+    "npm-run-all": "^4.1.5",
+    "rimraf": "^3.0.2",
     "source-map-loader": "^0.2.4",
     "ts-node": "^8.3.0",
     "tsc": "^1.20150623.0",

--- a/src/middleware/oas3.options.ts
+++ b/src/middleware/oas3.options.ts
@@ -1,19 +1,24 @@
 import { OpenApiValidatorOpts } from 'express-openapi-validator/dist/framework/types';
 import { LoggingOptions } from './logging.options'
 import { SwaggerUiOptions } from './swagger.ui.options';
+import { XmlOptions } from './xml.options';
 
 export class Oas3AppOptions {
     public routing: any;
     public openApiValidator: OpenApiValidatorOpts;
     public logging: LoggingOptions;
     public swaggerUI: SwaggerUiOptions;
+    public xml: XmlOptions;
 
-    constructor(routingOpts: any, openApiValidatorOpts: OpenApiValidatorOpts, logging: LoggingOptions, swaggerUI: SwaggerUiOptions) {
+    constructor(routingOpts: any, openApiValidatorOpts: OpenApiValidatorOpts, logging: LoggingOptions, swaggerUI: SwaggerUiOptions, xml: XmlOptions) {
         this.routing = routingOpts;
         this.openApiValidator = openApiValidatorOpts;
         this.swaggerUI = swaggerUI;
         if (!logging)
             logging = new LoggingOptions(null, null);
         this.logging = logging;
+        if (!xml)
+            xml = new XmlOptions(null, null, null);
+        this.xml = xml;
     }
 }

--- a/src/middleware/xml.options.ts
+++ b/src/middleware/xml.options.ts
@@ -1,0 +1,12 @@
+export class XmlOptions {
+    public tagNameProcessors: 'array';
+    public valueProcessors: 'array';
+    public sanitiseProcessors: (req, res, next) => any;
+
+    constructor(tagNameProcessors: 'array', valueProcessors: 'array', sanitiseProcessors: (req, res, next) => any)
+    {
+        this.tagNameProcessors = tagNameProcessors;
+        this.valueProcessors = valueProcessors;
+        this.sanitiseProcessors = sanitiseProcessors;
+    }
+}


### PR DESCRIPTION
Added support for '*/xml'  content-type.

Added project dependencies to 'body-parser-xml' and 'xml2js' (to have default processors).
Added the capacity to set options for  body-parser-xml processors
Added the capacity to set options for a sanitiser function to solve issues that body-parser-xml is unable to, for example to force a property to be of type array when the xml parser set it as a string.

Changed the example to also demonstrate the use of XML.