### PR TITLE
Update router behavior if req.openapi is undefined

### DIFF
--- a/src/middleware/swagger.router.ts
+++ b/src/middleware/swagger.router.ts
@@ -105,6 +105,10 @@ export class SwaggerRouter {
       let handlerName;
       let rErr;
 
+      if (isUndefined(req.openapi)) {
+        return next(rErr);
+      }
+      
       debug('%s %s', req.method, req.url);
       debug('  Will process: %s', isUndefined(operation) ? 'no' : 'yes');
 


### PR DESCRIPTION
Generally, if req.openapi is undefined, the request either doesn't fall within the API's scope or is expressly excluded.  Either way, we should be passing it along to the next middleware rather than sending a 405 status code.