### PR TITLE
Fix issue with case sensitive route naming mismatch

### DIFF
--- a/src/middleware/swagger.router.ts
+++ b/src/middleware/swagger.router.ts
@@ -36,7 +36,7 @@ export class SwaggerRouter {
 
           if (isPlainObject(controller)) {
             each(controller, function (value, name) {
-              let handlerId = controllerName + '_' + name;
+              let handlerId = (controllerName + '_' + name).toLowerCase();
 
               debug('      %s%s',
                   handlerId,
@@ -87,7 +87,7 @@ export class SwaggerRouter {
       if (req.openapi.schema['x-swagger-router-controller']) {
         let operationId = req.openapi.schema.operationId ? req.openapi.schema.operationId : req.method.toLowerCase();
         operationId = removeDashElementToCamelCase(operationId);
-        return req.openapi.schema['x-swagger-router-controller'] + '_' + operationId;
+        return (req.openapi.schema['x-swagger-router-controller'] + '_' + operationId).toLocaleLowerCase();
       } else {
         return removeDashElementToCamelCase(req.openapi.schema.operationId);
       }


### PR DESCRIPTION
Fix for a case-sensitive route naming mismatch.

Bug reproduce and details:

See for the issue example [this spec](https://github.com/casanet/mock-server/blob/main/api/openapi.yaml). 

When trying to call the `/API/auth/login` generated route, the key in the [handlerCache](https://github.com/bug-hunters/oas3-tools/blob/master/src/middleware/swagger.router.ts#L58) is `Authentication_login`, while the `handlerName` calculated by [getHandlerName](https://github.com/bug-hunters/oas3-tools/blob/master/src/middleware/swagger.router.ts#L86) is `Authentication_Login`, and because of this mismatch the request got 

```Route defined in OpenAPI specification (/API/auth/login) but there is no defined onPOST operation.``` 

with `405` status code.