### PR TITLE
add support pdf in body of request

### DIFF
--- a/src/middleware/express.app.config.ts
+++ b/src/middleware/express.app.config.ts
@@ -30,6 +30,7 @@ export class ExpressAppConfig {
         this.app.use(bodyParser.urlencoded());
         this.app.use(bodyParser.text());
         this.app.use(bodyParser.json());
+        this.app.use(bodyParser.raw({ type: 'application/pdf' }));
 
         this.app.use(this.configureLogger(appOptions.logging));
         this.app.use(express.json());


### PR DESCRIPTION
I have a problem, there is no way to send pdf files in the request body. This functionality is very necessary, I don't know how to fix it without updating the library.

Please publish these changes ASAP. Thanks.