### PR TITLE
feat(custom-middleware): added support of custom middlewares binding

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
 'use strict';
 import { ExpressAppConfig } from "./middleware/express.app.config";
 import { Oas3AppOptions } from "./middleware/oas3.options";
+import { OpenApiRequestHandler } from 'express-openapi-validator/dist/framework/types'
 
-export function expressAppConfig(definitionPath: string, appOptions: Oas3AppOptions): ExpressAppConfig {
-  return new ExpressAppConfig(definitionPath, appOptions);
+export function expressAppConfig(
+  definitionPath: string,
+  appOptions: Oas3AppOptions,
+  customMiddlewares?: OpenApiRequestHandler[]
+): ExpressAppConfig {
+  return new ExpressAppConfig(definitionPath, appOptions, customMiddlewares);
 }

--- a/src/middleware/express.app.config.ts
+++ b/src/middleware/express.app.config.ts
@@ -11,6 +11,7 @@ import * as fs from 'fs';
 import * as jsyaml from 'js-yaml';
 import * as OpenApiValidator from 'express-openapi-validator';
 import { Oas3AppOptions } from './oas3.options';
+import { OpenApiRequestHandler } from 'express-openapi-validator/dist/framework/types'
 
 export class ExpressAppConfig {
     private app: express.Application;
@@ -18,7 +19,7 @@ export class ExpressAppConfig {
     private definitionPath;
     private openApiValidatorOptions;
 
-    constructor(definitionPath: string, appOptions: Oas3AppOptions) {
+    constructor(definitionPath: string, appOptions: Oas3AppOptions, customMiddlewares?: OpenApiRequestHandler[]) {
         this.definitionPath = definitionPath;
         this.routingOptions = appOptions.routing;
         this.setOpenApiValidatorOptions(definitionPath, appOptions);
@@ -41,6 +42,8 @@ export class ExpressAppConfig {
 
         this.app.use(OpenApiValidator.middleware(this.openApiValidatorOptions));
         this.app.use(new SwaggerParameters().checkParameters());
+        // Bind custom middlewares which need access to the OpenApiRequest context before controllers initialization
+        (customMiddlewares || []).forEach(middleware => this.app.use(middleware))
         this.app.use(new SwaggerRouter().initialize(this.routingOptions));
 
         this.app.use(this.errorHandler);


### PR DESCRIPTION
I faced issue with binding middleware right before controllers handlers triggered (to have access to the context of `OpenApiRequest` within middleweare). I need this to have access to custom properties (aka `x-*`) from `OAS` definition. 
My use case - deserialize request body (projection to DTO) and attach it to the request, so the controller receives request with 
clearly defined typed 'DTO' in it (removes bunch of boilerplate code from the controller layer).

In this PR I added additional argument to the `ExpressAppConfig::constructor` which is collection of middlewares (`OpenApiRequestHandler[]`) from the client side and bind those handlers right before router initialization.

I didn't found existed solution for this, if there is solution, please point out.