### PR TITLE
Allow support for application/json-path+json content type

### DIFF
--- a/src/middleware/express.app.config.ts
+++ b/src/middleware/express.app.config.ts
@@ -38,7 +38,8 @@ export class ExpressAppConfig {
         this.app.use(bodyParser.raw({ type: 'application/pdf' }));
 
         this.app.use(this.configureLogger(appOptions.logging));
-        this.app.use(express.json());
+        this.app.use(express.json({ type: 'application/*+json' }));
+
         this.app.use(express.urlencoded({ extended: false }));
         this.app.use(cookieParser());
 


### PR DESCRIPTION
RFC 6902 describes the usage of content-type `application/json-patch+json`. When initializing the express, I specifically allow any application/*+json so I can implement PATCHing json as indicated by the rfc.